### PR TITLE
feat!: Basic implementation of the Query API.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@
 [versions]
 junit-jupiter = "5.11.3"
 kotest = "6.0.0.M1"
+kotlin = "2.0.21"
 mockito = "5.14.2"
 mockk = "1.13.13"
 mysql-driver = "8.0.33"
@@ -13,6 +14,7 @@ test-conatainers = "1.20.3"
 [libraries]
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+kotlin-reflect = { module ="org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin"}
 # mockito only to be used from Java code (API usability test)
 mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
@@ -28,6 +30,6 @@ test-containers = ["test-cotainers-junit", "test-containers-junit-mysql", "test-
 test-dbs = ["mysql-driver", "postgresql-driver"]
 
 [plugins]
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.0.21" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version = "0.7.3" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "12.1.1" }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -98,6 +98,8 @@ tasks.check {
 }
 
 dependencies {
+    implementation(libs.kotlin.reflect)
+
     testImplementation(libs.mockito)
     testImplementation(libs.bundles.test)
 

--- a/lib/src/integrationTest/kotlin/net/samyn/kapper/QueryTests.kt
+++ b/lib/src/integrationTest/kotlin/net/samyn/kapper/QueryTests.kt
@@ -4,7 +4,6 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Named.named
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.TestInstance
@@ -91,8 +90,7 @@ class QueryTests {
 
     @ParameterizedTest()
     @MethodSource("databaseContainers")
-    @Disabled("TODO")
-    fun `should query all users`(container: JdbcDatabaseContainer<*>) {
+    fun `should query all heros`(container: JdbcDatabaseContainer<*>) {
         createConnection(container).use { connection ->
             val heroes = connection.query<SuperHero>("SELECT * FROM super_heroes")
             heroes.shouldContainExactlyInAnyOrder(
@@ -105,8 +103,7 @@ class QueryTests {
 
     @ParameterizedTest
     @MethodSource("databaseContainers")
-    @Disabled("TODO")
-    fun `should query users with condition`(container: JdbcDatabaseContainer<*>) {
+    fun `should query heros with condition`(container: JdbcDatabaseContainer<*>) {
         createConnection(container).use { connection ->
             val heroes = connection.query<SuperHero>("SELECT * FROM super_heroes WHERE age > :age", "age" to 80)
             heroes.shouldContainExactlyInAnyOrder(
@@ -118,13 +115,12 @@ class QueryTests {
 
     @ParameterizedTest
     @MethodSource("databaseContainers")
-    @Disabled("TODO")
     fun `should query specific columns`(container: JdbcDatabaseContainer<*>) {
         createConnection(container).use { connection ->
             val heroes =
                 connection.query<SuperHero>(
                     "SELECT id, name FROM super_heroes WHERE name = :name",
-                    "name" to superman,
+                    "name" to superman.name,
                 )
             heroes.shouldContainExactlyInAnyOrder(
                 SuperHero(superman.id, superman.name),
@@ -134,7 +130,6 @@ class QueryTests {
 
     @ParameterizedTest
     @MethodSource("databaseContainers")
-    @Disabled("TODO")
     fun `should handle empty result set`(container: JdbcDatabaseContainer<*>) {
         createConnection(container).use { connection ->
             val heroes =
@@ -148,7 +143,6 @@ class QueryTests {
 
     @ParameterizedTest
     @MethodSource("databaseContainers")
-    @Disabled("TODO")
     fun `should query with multiple conditions`(container: JdbcDatabaseContainer<*>) {
         createConnection(container).use { connection ->
             val heroes =

--- a/lib/src/main/kotlin/net/samyn/kapper/Exceptions.kt
+++ b/lib/src/main/kotlin/net/samyn/kapper/Exceptions.kt
@@ -1,0 +1,10 @@
+package net.samyn.kapper
+
+class KapperMappingException(message: String, cause: Throwable? = null) :
+    RuntimeException(message, cause)
+
+class KapperUnsupportedOperationException(message: String, cause: Throwable? = null) :
+    RuntimeException(message, cause)
+
+class KapperParseException(message: String, cause: Throwable? = null) :
+    RuntimeException(message, cause)

--- a/lib/src/main/kotlin/net/samyn/kapper/internal/AutoConverter.kt
+++ b/lib/src/main/kotlin/net/samyn/kapper/internal/AutoConverter.kt
@@ -1,0 +1,38 @@
+package net.samyn.kapper.internal
+
+import net.samyn.kapper.KapperUnsupportedOperationException
+import java.nio.ByteBuffer
+import java.util.UUID
+import kotlin.reflect.KClass
+
+object AutoConverter {
+    fun convert(
+        value: Any,
+        target: KClass<*>,
+    ): Any {
+        val converted =
+            when (target) {
+                UUID::class -> {
+                    return if (value is String) {
+                        UUID.fromString(value)
+                    } else if (value is ByteArray) {
+                        value.asUUID()
+                    } else {
+                        throw KapperUnsupportedOperationException(
+                            "Cannot auto-convert from ${value.javaClass} to ${target::class.java}",
+                        )
+                    }
+                }
+                else ->
+                    throw KapperUnsupportedOperationException(
+                        "Cannot auto-convert from ${value.javaClass} to ${target::class.java}",
+                    )
+            }
+        return converted
+    }
+
+    private fun ByteArray.asUUID(): UUID {
+        val b = ByteBuffer.wrap(this)
+        return UUID(b.getLong(), b.getLong())
+    }
+}

--- a/lib/src/main/kotlin/net/samyn/kapper/internal/KapperImpl.kt
+++ b/lib/src/main/kotlin/net/samyn/kapper/internal/KapperImpl.kt
@@ -1,0 +1,101 @@
+package net.samyn.kapper.internal
+
+import net.samyn.kapper.Kapper
+import net.samyn.kapper.KapperParseException
+import java.sql.Connection
+import java.sql.ResultSet
+import java.util.HashMap
+
+// TODO: this is only covered by the TestContainer integration tests.
+//  Break this up further and ensure unit test coverage.
+class KapperImpl(
+    val sqlTypesConverter: (Int, String, ResultSet, String) -> Any = SQLTypesConverter::convert,
+) : Kapper {
+    override fun <T : Any> query(
+        clazz: Class<T>,
+        connection: Connection,
+        sql: String,
+        args: HashMap<String, Any?>,
+    ): List<T> = query(clazz, connection, sql, args.toMap())
+
+    override fun <T : Any> query(
+        clazz: Class<T>,
+        connection: Connection,
+        sql: String,
+        args: Map<String, Any?>,
+    ): List<T> {
+        // TODO: cache query
+        val query = Query(sql)
+        // TODO: cash mapper/type reflection
+        // TODO: allow multiple constructors and non-data classes
+        val mapper = Mapper(clazz)
+        val results = mutableListOf<T>()
+        connection.prepareStatement(query.sql).use { stmt ->
+            args.forEach { a ->
+                val indexes =
+                    query.tokens[a.key]
+                        ?: throw KapperParseException("Token with name `${a.key}' not found in template")
+                indexes.forEach { i ->
+                    // TODO: allow custom SQL type conversion?
+                    stmt.setObject(i, a.value)
+                }
+            }
+            // TODO: introduce SLF4J
+            println(stmt)
+            // TODO: create overload that takes custom conversion function and defaults to this
+            stmt.executeQuery().use { rs ->
+                // TODO: cache data
+                // TODO: structure nicer
+                val fields =
+                    (1..rs.metaData.columnCount).map {
+                        rs.metaData.getColumnName(it) to
+                            Pair(rs.metaData.getColumnType(it), rs.metaData.getColumnTypeName(it))
+                    }
+                while (rs.next()) {
+                    results.add(
+                        mapper.createInstance(
+                            fields.map { field ->
+                                Mapper.ColumnValue(
+                                    field.first,
+                                    sqlTypesConverter(field.second.first, field.second.second, rs, field.first),
+                                )
+                            },
+                        ),
+                    )
+                }
+            }
+        }
+
+        return results
+    }
+
+    override fun <T : Any> querySingle(
+        clazz: Class<T>,
+        connection: Connection,
+        sql: String,
+        args: HashMap<String, Any?>,
+    ): T = querySingle(clazz, connection, sql, args.toMap())
+
+    override fun <T : Any> querySingle(
+        clazz: Class<T>,
+        connection: Connection,
+        sql: String,
+        args: Map<String, Any?>,
+    ): T {
+        TODO("Not yet implemented")
+    }
+
+    override fun execute(
+        connection: Connection,
+        sql: String,
+        args: HashMap<String, Any?>,
+    ): Int = execute(connection, sql, args.toMap())
+
+    override fun execute(
+        connection: Connection,
+        sql: String,
+        args: Map<String, Any?>,
+    ): Int {
+        TODO("Not yet implemented")
+    }
+}

--- a/lib/src/main/kotlin/net/samyn/kapper/internal/Mapper.kt
+++ b/lib/src/main/kotlin/net/samyn/kapper/internal/Mapper.kt
@@ -1,0 +1,52 @@
+package net.samyn.kapper.internal
+
+import net.samyn.kapper.KapperMappingException
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.primaryConstructor
+
+class Mapper<T : Any>(
+    val clazz: Class<T>,
+    val autoConverter: (Any, KClass<*>) -> Any = AutoConverter::convert,
+) {
+    // TODO: relax case sensitivity of tokens names?
+    private val constructor: KFunction<T> =
+        clazz.kotlin.primaryConstructor
+            ?: throw KapperMappingException("No primary constructor found for ${clazz.name}")
+    private val properties =
+        constructor.parameters
+            .map { it.name to it }.toMap()
+
+    fun createInstance(columns: List<ColumnValue>): T {
+        if (columns.size > properties.size) {
+            throw KapperMappingException(
+                "Too many tokens provided in the template: ${columns.map { it.name }}. " +
+                    "Constructor for ${clazz.name} only has: ${properties.keys}",
+            )
+        } else if (columns.size < properties.size) {
+            val all = columns.map { it.name }
+            val missing = properties.filter { !it.value.isOptional && !all.contains(it.value.name) }
+            if (missing.isNotEmpty()) {
+                throw KapperMappingException("The following properties are non-optional and missing: ${missing.keys}")
+            }
+        }
+        val args =
+            columns.map {
+                val prop =
+                    properties[it.name]
+                        ?: throw KapperMappingException("No property found for ${it.name}")
+                // TODO: optimise this
+                if (it.value == null) {
+                    prop to null
+                } else if (it.value::class != prop.type.classifier) {
+                    prop to autoConverter(it.value, prop.type.classifier as KClass<*>)
+                } else {
+                    prop to it.value
+                }
+            }.toMap()
+        val instance = constructor.callBy(args)
+        return instance
+    }
+
+    data class ColumnValue(val name: String, val value: Any?)
+}

--- a/lib/src/main/kotlin/net/samyn/kapper/internal/Query.kt
+++ b/lib/src/main/kotlin/net/samyn/kapper/internal/Query.kt
@@ -1,0 +1,71 @@
+package net.samyn.kapper.internal
+
+import net.samyn.kapper.KapperParseException
+
+/**
+ * Represents a Query.
+ *
+ * @param template the query template
+ * @property sql the JDBC formatted query string with placeholders
+ * @property tokens the tokens and their indexes in the query string
+ */
+data class Query(
+    val template: String,
+    private val queryParser: (String) -> Pair<String, Map<String, List<Int>>> = QueryParser::parseQuery,
+) {
+    val sql: String
+    val tokens: Map<String, List<Int>>
+
+    init {
+        val (sql: String, tokens: Map<String, List<Int>>) = queryParser(template)
+        this.sql = sql
+        this.tokens = tokens
+    }
+}
+
+object QueryParser {
+    fun parseQuery(template: String): Pair<String, Map<String, List<Int>>> {
+        val sqlBuilder = StringBuilder()
+        val tokens = mutableMapOf<String, MutableList<Int>>()
+        var tokenIndex = 0
+        var tokenNameBuilder: StringBuilder? = null
+
+        template.forEachIndexed { i, c ->
+            when {
+                // Token start char and it follows at least one valid token character
+                c.isTokenStart() && template.getOrNull(i + 1)?.isValidTokenChar() == true -> {
+                    tokenNameBuilder = StringBuilder()
+                    tokenIndex++
+                    sqlBuilder.append('?')
+                }
+                tokenNameBuilder != null -> {
+                    // valid token character
+                    if (c.isValidTokenChar()) {
+                        tokenNameBuilder.append(c)
+                        // valid token separator character
+                    } else if (c.isValidTokenSeparator()) {
+                        tokens.getOrPut(tokenNameBuilder.toString()) { mutableListOf() }.add(tokenIndex)
+                        tokenNameBuilder = null
+                        sqlBuilder.append(c)
+                    } else {
+                        throw KapperParseException("$c is not a valid character part of the template token.")
+                    }
+                }
+                else -> sqlBuilder.append(c)
+            }
+        }
+
+        // Handle case where token is at the end of the string
+        tokenNameBuilder?.let {
+            tokens.getOrPut(tokenNameBuilder.toString()) { mutableListOf() }.add(tokenIndex)
+        }
+
+        return sqlBuilder.toString() to tokens
+    }
+
+    private fun Char.isTokenStart() = this == ':' || this == '@'
+
+    private fun Char.isValidTokenChar() = this.isLetterOrDigit() || this == '_' || this == '-'
+
+    private fun Char.isValidTokenSeparator() = this == ' ' || this == ',' || this == ')'
+}

--- a/lib/src/main/kotlin/net/samyn/kapper/internal/SQLTypesConverter.kt
+++ b/lib/src/main/kotlin/net/samyn/kapper/internal/SQLTypesConverter.kt
@@ -1,0 +1,65 @@
+package net.samyn.kapper.internal
+
+import java.sql.JDBCType
+import java.sql.ResultSet
+import java.sql.Types
+import java.util.UUID
+
+// TODO: this could be more sophisticated by allowing type conversion hints.
+// TODO: check what hibernate does for these conversions.
+object SQLTypesConverter {
+    fun convert(
+        sqlType: Int,
+        sqlTypeName: String,
+        resultSet: ResultSet,
+        field: String,
+    ): Any {
+        val result =
+            when (sqlType) {
+                Types.ARRAY -> resultSet.getArray(field)
+                Types.BIGINT -> resultSet.getLong(field)
+                in listOf(Types.BINARY, Types.BLOB, Types.LONGVARBINARY, Types.VARBINARY),
+                -> resultSet.getBytes(field)
+                in listOf(Types.BIT, Types.BOOLEAN) -> resultSet.getBoolean(field)
+                in
+                listOf(
+                    Types.CHAR, Types.CLOB, Types.LONGNVARCHAR, Types.LONGVARCHAR,
+                    Types.NCHAR, Types.NCLOB, Types.NVARCHAR, Types.ROWID, Types.SQLXML, Types.VARCHAR,
+                ),
+                -> resultSet.getString(field)
+                in listOf(Types.DATE),
+                -> resultSet.getDate(field)
+                in listOf(Types.DECIMAL, Types.FLOAT, Types.NUMERIC, Types.REAL),
+                -> resultSet.getFloat(field)
+                Types.DOUBLE -> resultSet.getDouble(field)
+                in listOf(Types.INTEGER, Types.SMALLINT, Types.TINYINT),
+                -> resultSet.getInt(field)
+                Types.JAVA_OBJECT,
+                -> resultSet.getObject(field)
+                // TODO: validate these with regards to timezones etc. This may be DB specific.
+                in
+                listOf(
+                    Types.TIME,
+                    Types.TIME_WITH_TIMEZONE,
+                ),
+                -> resultSet.getTime(field).toInstant()
+                in
+                listOf(
+                    Types.TIMESTAMP,
+                    Types.TIMESTAMP_WITH_TIMEZONE,
+                ),
+                -> resultSet.getTimestamp(field).toInstant()
+
+                // includes: DATALINK, DISTINCT, OTHER, REF, REF_CURSOR, STRUCT, NULL
+                else -> {
+                    // use name if type is
+                    when (sqlTypeName.lowercase()) {
+                        "uuid" -> UUID.fromString(resultSet.getString(field))
+                        else ->
+                            throw UnsupportedOperationException("Conversion from type ${JDBCType.valueOf(sqlType)} is not supported")
+                    }
+                }
+            }
+        return result
+    }
+}

--- a/lib/src/test/kotlin/net/samyn/kapper/AutoConverterTest.kt
+++ b/lib/src/test/kotlin/net/samyn/kapper/AutoConverterTest.kt
@@ -1,0 +1,45 @@
+package net.samyn.kapper
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import net.samyn.kapper.internal.AutoConverter
+import org.junit.jupiter.api.Test
+import java.nio.ByteBuffer
+import java.util.UUID
+
+class AutoConverterTest {
+    @Test
+    fun `when string UUID convert`() {
+        val uuid = "123e4567-e89b-12d3-a456-426614174000"
+        val autoConvertedUuid = AutoConverter.convert(uuid, UUID::class)
+        autoConvertedUuid.shouldBe(UUID.fromString(uuid))
+    }
+
+    @Test
+    fun `when binary UUID convert`() {
+        val uuid = UUID.fromString("123e4567-e89b-12d3-a456-426614174000")
+        val autoConvertedUuid = AutoConverter.convert(uuid.asBytes(), UUID::class)
+        autoConvertedUuid.shouldBe(uuid)
+    }
+
+    @Test
+    fun `when invalid source type throw`() {
+        shouldThrow<KapperUnsupportedOperationException> {
+            AutoConverter.convert(123, UUID::class)
+        }
+    }
+
+    @Test
+    fun `when invalid target type throw`() {
+        shouldThrow<KapperUnsupportedOperationException> {
+            AutoConverter.convert("123", String::class)
+        }
+    }
+
+    private fun UUID.asBytes(): ByteArray {
+        val b = ByteBuffer.wrap(ByteArray(16))
+        b.putLong(mostSignificantBits)
+        b.putLong(leastSignificantBits)
+        return b.array()
+    }
+}

--- a/lib/src/test/kotlin/net/samyn/kapper/KapperTest.kt
+++ b/lib/src/test/kotlin/net/samyn/kapper/KapperTest.kt
@@ -1,3 +1,0 @@
-package net.samyn.kapper
-
-class KapperTest

--- a/lib/src/test/kotlin/net/samyn/kapper/MapperTest.kt
+++ b/lib/src/test/kotlin/net/samyn/kapper/MapperTest.kt
@@ -1,0 +1,95 @@
+package net.samyn.kapper
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import net.samyn.kapper.internal.Mapper
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.reflect.KClass
+
+class MapperTest {
+    private val autoMapperMock = mockk<(Any, KClass<*>) -> Any>()
+    private val mapper = Mapper<SuperHero>(SuperHero::class.java, autoMapperMock)
+
+    @Test
+    fun `should map to super hero`() {
+        val batman = SuperHero(UUID.randomUUID(), "Batman", "batman@dc.com", 85)
+
+        val instance =
+            mapper.createInstance(
+                listOf(
+                    Mapper.ColumnValue("id", batman.id),
+                    Mapper.ColumnValue("name", batman.name),
+                    Mapper.ColumnValue("email", batman.email),
+                    Mapper.ColumnValue("age", batman.age),
+                ),
+            )
+
+        instance.shouldBe(batman)
+    }
+
+    @Test
+    fun `should map to super hero respecting defaults`() {
+        val batman = SuperHero(UUID.randomUUID(), "Batman", "batman@dc.com", 85)
+
+        val instance =
+            mapper.createInstance(
+                listOf(
+                    Mapper.ColumnValue("id", batman.id),
+                    Mapper.ColumnValue("name", batman.name),
+                ),
+            )
+
+        instance.shouldBe(SuperHero(batman.id, "Batman", null, null))
+    }
+
+    @Test
+    fun `should throw when too many columns`() {
+        val ex =
+            shouldThrow<KapperMappingException> {
+                mapper.createInstance(
+                    listOf(
+                        Mapper.ColumnValue("id", UUID.randomUUID()),
+                        Mapper.ColumnValue("name", "joker"),
+                        Mapper.ColumnValue("email", "joker@dc.com"),
+                        Mapper.ColumnValue("age", 85),
+                        Mapper.ColumnValue("foo", "bar"),
+                    ),
+                )
+            }
+        ex.message.shouldContain("foo")
+    }
+
+    @Test
+    fun `should throw when non-optional are missing`() {
+        val ex =
+            shouldThrow<KapperMappingException> {
+                mapper.createInstance(
+                    listOf(
+                        Mapper.ColumnValue("name", "joker"),
+                        Mapper.ColumnValue("email", "joker@dc.com"),
+                        Mapper.ColumnValue("age", 85),
+                    ),
+                )
+            }
+        ex.message.shouldContain("id")
+    }
+
+    @Test
+    fun `should convert when type not known`() {
+        every { autoMapperMock(any<Int>(), any<KClass<*>>()) } returns "Foo"
+        mapper.createInstance(
+            listOf(
+                Mapper.ColumnValue("id", UUID.randomUUID()),
+                Mapper.ColumnValue("name", 123),
+            ),
+        )
+        verify { autoMapperMock(123, String::class) }
+    }
+
+    data class SuperHero(val id: UUID, val name: String, val email: String? = null, val age: Int? = null)
+}

--- a/lib/src/test/kotlin/net/samyn/kapper/QueryParserTest.kt
+++ b/lib/src/test/kotlin/net/samyn/kapper/QueryParserTest.kt
@@ -1,0 +1,103 @@
+package net.samyn.kapper
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import net.samyn.kapper.internal.QueryParser
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class QueryParserTest {
+    @ParameterizedTest
+    @MethodSource("provideQueryTemplates")
+    fun `should parse query templates correctly`(
+        template: String,
+        expectedSql: String,
+        expectedTokens: Map<String, Int>,
+    ) {
+        val (actualSql, actualTokens) = QueryParser.parseQuery(template)
+        assertSoftly {
+            actualSql.shouldBe(expectedSql)
+            actualTokens.shouldContainExactly(expectedTokens)
+        }
+    }
+
+    @Test
+    fun `when no tokens return empty map`() {
+        val template = "SELECT * FROM super_hero"
+        val query = QueryParser.parseQuery(template)
+        query.shouldBe(template to emptyMap())
+    }
+
+    @Test
+    fun `when token is at the beginning of the query`() {
+        val template = ":id = 1 AND name = 'John'"
+        val (sql, tokens) = QueryParser.parseQuery(template)
+        sql.shouldBe("? = 1 AND name = 'John'")
+        tokens.shouldContainExactly(mapOf("id" to listOf(1)))
+    }
+
+    @Test
+    fun `when tokens are repeated`() {
+        val template = "WHERE id = :id OR parent_id = :id"
+        val (sql, tokens) = QueryParser.parseQuery(template)
+        sql.shouldBe("WHERE id = ? OR parent_id = ?")
+        tokens.shouldContainExactly(mapOf("id" to listOf(1, 2)))
+    }
+
+    @Test
+    fun `when token contains numbers`() {
+        val template = "WHERE id = :id1 AND name = :name2"
+        val (sql, tokens) = QueryParser.parseQuery(template)
+        sql.shouldBe("WHERE id = ? AND name = ?")
+        tokens.shouldContainExactly(
+            mapOf("id1" to listOf(1), "name2" to listOf(2)),
+        )
+    }
+
+    @Test
+    fun `when query is very large`() {
+        val largeTemplate = "SELECT * FROM table WHERE " + (1..1000).joinToString(" AND ") { "column$it = :param$it" }
+        val (sql, tokens) = QueryParser.parseQuery(largeTemplate)
+        sql.shouldBe("SELECT * FROM table WHERE " + (1..1000).joinToString(" AND ") { "column$it = ?" })
+        tokens.size.shouldBe(1000)
+    }
+
+    @Test
+    fun `when invalid token character is used`() {
+        val template = "WHERE id = :id! AND name = :name"
+        assertThrows<KapperParseException> {
+            QueryParser.parseQuery(template)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun provideQueryTemplates() =
+            listOf(
+                Arguments.of(
+                    "SELECT * FROM super_hero WHERE id = :id",
+                    "SELECT * FROM super_hero WHERE id = ?",
+                    mapOf("id" to listOf(1)),
+                ),
+                Arguments.of(
+                    "SELECT * FROM super_hero WHERE id = @id",
+                    "SELECT * FROM super_hero WHERE id = ?",
+                    mapOf("id" to listOf(1)),
+                ),
+                Arguments.of(
+                    "INSERT INTO super_hero(id, name) VALUES (:id, :name) RETURNING *",
+                    "INSERT INTO super_hero(id, name) VALUES (?, ?) RETURNING *",
+                    mapOf("id" to listOf(1), "name" to listOf(2)),
+                ),
+                Arguments.of(
+                    "UPDATE super_hero SET name = :name WHERE id = :id",
+                    "UPDATE super_hero SET name = ? WHERE id = ?",
+                    mapOf("name" to listOf(1), "id" to listOf(2)),
+                ),
+            )
+    }
+}


### PR DESCRIPTION
- Implemented the basic functionality of the Query API, including methods for executing queries and mapping results to Kotlin data classes.
- Added AutoConverter for automatic type conversion, specifically handling UUID conversions.
Introduced KapperImpl class to handle query execution and result mapping.
- Added Mapper class to map SQL results to Kotlin data classes, with logic for handling optional properties.
- Implemented Query and QueryParser for parsing SQL query templates.
- Added SQLTypesConverter for converting SQL types to appropriate Kotlin types.
- Enabled and updated integration tests for querying functionality.
- Added unit tests for AutoConverter, Mapper, and QueryParser functionalities.
- Updated dependencies and configuration in build.gradle.kts and libs.versions.toml.

Missing: an additional overload on the API to optionally be able to specify a custom row -> class converter function which would allow for more complex use-cases.