### PR TITLE
Fix: column mapping issue with mySQL

### DIFF
--- a/lib/src/integrationTest/kotlin/net/samyn/kapper/QueryTests.kt
+++ b/lib/src/integrationTest/kotlin/net/samyn/kapper/QueryTests.kt
@@ -2,6 +2,7 @@ package net.samyn.kapper
 
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldContainOnly
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -75,6 +76,22 @@ class QueryTests : AbstractDbTests() {
             heroes.shouldContainExactlyInAnyOrder(
                 superman,
                 batman,
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("databaseContainers")
+    fun `support field labels`(container: JdbcDatabaseContainer<*>) {
+        data class SimpleClass(val superHeroName: String)
+        createConnection(container).use { connection ->
+            val hero =
+                connection.query<SimpleClass>(
+                    "SELECT name as superHeroName FROM super_heroes WHERE id = :id",
+                    "id" to superman.id,
+                )
+            hero.shouldContainOnly(
+                SimpleClass(superman.name),
             )
         }
     }

--- a/lib/src/main/kotlin/net/samyn/kapper/Field.kt
+++ b/lib/src/main/kotlin/net/samyn/kapper/Field.kt
@@ -4,7 +4,8 @@ import java.sql.JDBCType
 
 /**
  * Represents a field in a DB row.
+ * @param columnIndex index of the column.
  * @param type JDBCType
  * @param name of the DB type as returned by the JDBC driver.
  */
-data class Field(val type: JDBCType, val typeName: String)
+data class Field(val columnIndex: Int, val type: JDBCType, val typeName: String)

--- a/lib/src/main/kotlin/net/samyn/kapper/internal/KapperImpl.kt
+++ b/lib/src/main/kotlin/net/samyn/kapper/internal/KapperImpl.kt
@@ -55,10 +55,14 @@ internal class KapperImpl : Kapper {
                 // TODO: cache data
                 // TODO: cash fields (persist in query?)
                 val fields =
-                    (1..rs.metaData.columnCount).map {
-                        rs.metaData.getColumnName(it) to
-                            Field(JDBCType.valueOf(rs.metaData.getColumnType(it)), rs.metaData.getColumnTypeName(it))
-                    }.toMap()
+                    (1..rs.metaData.columnCount).associate {
+                        rs.metaData.getColumnLabel(it) to
+                            Field(
+                                it,
+                                JDBCType.valueOf(rs.metaData.getColumnType(it)),
+                                rs.metaData.getColumnTypeName(it),
+                            )
+                    }
                 while (rs.next()) {
                     results.add(
                         mapper(rs, fields),

--- a/lib/src/main/kotlin/net/samyn/kapper/internal/SQLTypesConverter.kt
+++ b/lib/src/main/kotlin/net/samyn/kapper/internal/SQLTypesConverter.kt
@@ -17,53 +17,53 @@ internal object SQLTypesConverter {
         sqlType: JDBCType,
         sqlTypeName: String,
         resultSet: ResultSet,
-        field: String,
+        fieldIndex: Int,
     ): Any {
         val result =
             when (sqlType) {
-                JDBCType.ARRAY -> resultSet.getArray(field)
-                JDBCType.BIGINT -> resultSet.getLong(field)
+                JDBCType.ARRAY -> resultSet.getArray(fieldIndex)
+                JDBCType.BIGINT -> resultSet.getLong(fieldIndex)
                 in listOf(JDBCType.BINARY, JDBCType.BLOB, JDBCType.LONGVARBINARY, JDBCType.VARBINARY),
-                -> resultSet.getBytes(field)
-                in listOf(JDBCType.BIT, JDBCType.BOOLEAN) -> resultSet.getBoolean(field)
+                -> resultSet.getBytes(fieldIndex)
+                in listOf(JDBCType.BIT, JDBCType.BOOLEAN) -> resultSet.getBoolean(fieldIndex)
                 in
                 listOf(JDBCType.CHAR),
-                -> resultSet.getString(field).toCharArray()[0]
+                -> resultSet.getString(fieldIndex).toCharArray()[0]
                 in
                 listOf(
                     JDBCType.CLOB, JDBCType.LONGNVARCHAR, JDBCType.LONGVARCHAR,
                     JDBCType.NCHAR, JDBCType.NCLOB, JDBCType.NVARCHAR, JDBCType.ROWID, JDBCType.SQLXML, JDBCType.VARCHAR,
                 ),
-                -> resultSet.getString(field)
+                -> resultSet.getString(fieldIndex)
                 in listOf(JDBCType.DATE),
-                -> Date(resultSet.getDate(field).time)
+                -> Date(resultSet.getDate(fieldIndex).time)
                 in listOf(JDBCType.DECIMAL, JDBCType.FLOAT, JDBCType.NUMERIC, JDBCType.REAL),
-                -> resultSet.getFloat(field)
+                -> resultSet.getFloat(fieldIndex)
                 JDBCType.DOUBLE ->
-                    resultSet.getDouble(field)
+                    resultSet.getDouble(fieldIndex)
                 in listOf(JDBCType.INTEGER, JDBCType.SMALLINT, JDBCType.TINYINT),
-                -> resultSet.getInt(field)
+                -> resultSet.getInt(fieldIndex)
                 JDBCType.JAVA_OBJECT,
-                -> resultSet.getObject(field)
+                -> resultSet.getObject(fieldIndex)
                 // TODO: validate these with regards to timezones etc. This may be DB specific.
                 in
                 listOf(
                     JDBCType.TIME,
                     JDBCType.TIME_WITH_TIMEZONE,
                 ),
-                -> resultSet.getTime(field).toLocalTime()
+                -> resultSet.getTime(fieldIndex).toLocalTime()
                 in
                 listOf(
                     JDBCType.TIMESTAMP,
                     JDBCType.TIMESTAMP_WITH_TIMEZONE,
                 ),
-                -> resultSet.getTimestamp(field).toInstant()
+                -> resultSet.getTimestamp(fieldIndex).toInstant()
 
                 // includes: DATALINK, DISTINCT, OTHER, REF, REF_CURSOR, STRUCT, NULL
                 else -> {
                     // use name if type is
                     when (sqlTypeName.lowercase()) {
-                        "uuid" -> UUID.fromString(resultSet.getString(field))
+                        "uuid" -> UUID.fromString(resultSet.getString(fieldIndex))
                         else ->
                             throw KapperUnsupportedOperationException("Conversion from type $sqlType is not supported")
                     }

--- a/lib/src/test/kotlin/net/samyn/kapper/MapperTest.kt
+++ b/lib/src/test/kotlin/net/samyn/kapper/MapperTest.kt
@@ -16,28 +16,28 @@ import kotlin.reflect.KClass
 class MapperTest {
     private val autoMapperMock = mockk<(Any, KClass<*>) -> Any>()
     private val resultSet = mockk<ResultSet>()
-    val sqlTypeConverterMock = mockk<(JDBCType, String, ResultSet, String) -> Any>()
+    val sqlTypeConverterMock = mockk<(JDBCType, String, ResultSet, Int) -> Any>()
 
     @Test
     fun `should map to super hero`() {
         val batman = SuperHero(UUID.randomUUID(), "Batman", "batman@dc.com", 85)
         val fields =
             mapOf(
-                "id" to Field(JDBCType.BIT, "SomeType"),
-                "name" to Field(JDBCType.BIT, "SomeType"),
-                "email" to Field(JDBCType.BIT, "SomeType"),
-                "age" to Field(JDBCType.BIT, "SomeType"),
+                "id" to Field(1, JDBCType.BIT, "SomeType"),
+                "name" to Field(2, JDBCType.BIT, "SomeType"),
+                "email" to Field(3, JDBCType.BIT, "SomeType"),
+                "age" to Field(4, JDBCType.BIT, "SomeType"),
             )
-        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<String>("id")) } returns
+        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<Int>(1)) } returns
             batman.id
-        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<String>("name")) } returns
+        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<Int>(2)) } returns
             batman.name
-        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<String>("email")) } returns
+        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<Int>(3)) } returns
             batman.email!!
-        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<String>("age")) } returns
+        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<Int>(4)) } returns
             batman.age!!
 
-        val mapper = Mapper<SuperHero>(SuperHero::class.java, autoMapperMock, sqlTypeConverterMock)
+        val mapper = Mapper(SuperHero::class.java, autoMapperMock, sqlTypeConverterMock)
         val instance = mapper.createInstance(resultSet, fields)
 
         instance.shouldBe(batman)
@@ -48,15 +48,15 @@ class MapperTest {
         val batman = SuperHero(UUID.randomUUID(), "Batman", "batman@dc.com", 85)
         val fields =
             mapOf(
-                "id" to Field(JDBCType.BIT, "SomeType"),
-                "name" to Field(JDBCType.BIT, "SomeType"),
+                "id" to Field(1, JDBCType.BIT, "SomeType"),
+                "name" to Field(2, JDBCType.BIT, "SomeType"),
             )
-        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<String>("id")) } returns
+        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<Int>(1)) } returns
             batman.id
-        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<String>("name")) } returns
+        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<Int>(2)) } returns
             batman.name
 
-        val mapper = Mapper<SuperHero>(SuperHero::class.java, autoMapperMock, sqlTypeConverterMock)
+        val mapper = Mapper(SuperHero::class.java, autoMapperMock, sqlTypeConverterMock)
         val instance = mapper.createInstance(resultSet, fields)
 
         instance.shouldBe(SuperHero(batman.id, "Batman", null, null))
@@ -66,24 +66,24 @@ class MapperTest {
     fun `should throw when too many columns`() {
         val fields =
             mapOf(
-                "id" to Field(JDBCType.BIT, "SomeType"),
-                "name" to Field(JDBCType.BIT, "SomeType"),
-                "email" to Field(JDBCType.BIT, "SomeType"),
-                "age" to Field(JDBCType.BIT, "SomeType"),
-                "foo" to Field(JDBCType.BIT, "SomeType"),
+                "id" to Field(1, JDBCType.BIT, "SomeType"),
+                "name" to Field(2, JDBCType.BIT, "SomeType"),
+                "email" to Field(3, JDBCType.BIT, "SomeType"),
+                "age" to Field(4, JDBCType.BIT, "SomeType"),
+                "foo" to Field(5, JDBCType.BIT, "SomeType"),
             )
-        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<String>("id")) } returns
+        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<Int>(1)) } returns
             UUID.randomUUID()
-        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<String>("name")) } returns
+        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<Int>(2)) } returns
             "joker"
-        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<String>("email")) } returns
+        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<Int>(3)) } returns
             "joker@dc.com"
-        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<String>("age")) } returns
+        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<Int>(4)) } returns
             85
-        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<String>("foo")) } returns
+        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<Int>(5)) } returns
             "bar"
 
-        val mapper = Mapper<SuperHero>(SuperHero::class.java, autoMapperMock, sqlTypeConverterMock)
+        val mapper = Mapper(SuperHero::class.java, autoMapperMock, sqlTypeConverterMock)
         val ex =
             shouldThrow<KapperMappingException> {
                 mapper.createInstance(resultSet, fields)
@@ -96,18 +96,18 @@ class MapperTest {
         val batman = SuperHero(UUID.randomUUID(), "Batman", "batman@dc.com", 85)
         val fields =
             mapOf(
-                "name" to Field(JDBCType.BIT, "SomeType"),
-                "email" to Field(JDBCType.BIT, "SomeType"),
-                "age" to Field(JDBCType.BIT, "SomeType"),
+                "name" to Field(1, JDBCType.BIT, "SomeType"),
+                "email" to Field(2, JDBCType.BIT, "SomeType"),
+                "age" to Field(3, JDBCType.BIT, "SomeType"),
             )
-        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<String>("name")) } returns
+        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<Int>(1)) } returns
             batman.name
-        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<String>("email")) } returns
+        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<Int>(2)) } returns
             batman.email!!
-        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<String>("age")) } returns
+        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<Int>(3)) } returns
             batman.age!!
 
-        val mapper = Mapper<SuperHero>(SuperHero::class.java, autoMapperMock, sqlTypeConverterMock)
+        val mapper = Mapper(SuperHero::class.java, autoMapperMock, sqlTypeConverterMock)
         val ex =
             shouldThrow<KapperMappingException> {
                 mapper.createInstance(resultSet, fields)
@@ -120,15 +120,15 @@ class MapperTest {
         every { autoMapperMock(any<Int>(), any<KClass<*>>()) } returns "Foo"
         val fields =
             mapOf(
-                "id" to Field(JDBCType.BIT, "SomeType"),
-                "name" to Field(JDBCType.BIT, "SomeType"),
+                "id" to Field(1, JDBCType.BIT, "SomeType"),
+                "name" to Field(2, JDBCType.BIT, "SomeType"),
             )
-        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<String>("id")) } returns
+        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<Int>(1)) } returns
             UUID.randomUUID()
-        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<String>("name")) } returns
+        every { sqlTypeConverterMock(any<JDBCType>(), any<String>(), any<ResultSet>(), eq<Int>(2)) } returns
             123
 
-        val mapper = Mapper<SuperHero>(SuperHero::class.java, autoMapperMock, sqlTypeConverterMock)
+        val mapper = Mapper(SuperHero::class.java, autoMapperMock, sqlTypeConverterMock)
         mapper.createInstance(resultSet, fields)
         verify { autoMapperMock(123, String::class) }
     }

--- a/lib/src/test/kotlin/net/samyn/kapper/SQLTypesConverterTest.kt
+++ b/lib/src/test/kotlin/net/samyn/kapper/SQLTypesConverterTest.kt
@@ -72,60 +72,60 @@ class SQLTypesConverterTest {
         @JvmStatic
         fun convertSQLTypeTests() =
             listOf(
-                arguments(named("ARRAY", JDBCType.ARRAY), "ARRAY", { f: String -> resultSet.getArray(f) }),
-                arguments(named("BIGINT", JDBCType.BIGINT), "BIGINT", { f: String -> resultSet.getLong(f) }),
-                arguments(named("BINARY", JDBCType.BINARY), "BINARY", { f: String -> resultSet.getBytes(f) }),
-                arguments(named("BLOB", JDBCType.BLOB), "BLOB", { f: String -> resultSet.getBytes(f) }),
+                arguments(named("ARRAY", JDBCType.ARRAY), "ARRAY", { f: Int -> resultSet.getArray(f) }),
+                arguments(named("BIGINT", JDBCType.BIGINT), "BIGINT", { f: Int -> resultSet.getLong(f) }),
+                arguments(named("BINARY", JDBCType.BINARY), "BINARY", { f: Int -> resultSet.getBytes(f) }),
+                arguments(named("BLOB", JDBCType.BLOB), "BLOB", { f: Int -> resultSet.getBytes(f) }),
                 arguments(
                     named("LONGVARBINARY", JDBCType.LONGVARBINARY),
                     "LONGVARBINARY",
-                    { f: String -> resultSet.getBytes(f) },
+                    { f: Int -> resultSet.getBytes(f) },
                 ),
-                arguments(named("VARBINARY", JDBCType.VARBINARY), "VARBINARY", { f: String -> resultSet.getBytes(f) }),
-                arguments(named("BIT", JDBCType.BIT), "BIT", { f: String -> resultSet.getBoolean(f) }),
-                arguments(named("BOOLEAN", JDBCType.BOOLEAN), "BOOLEAN", { f: String -> resultSet.getBoolean(f) }),
-                arguments(named("CLOB", JDBCType.CLOB), "CLOB", { f: String -> resultSet.getString(f) }),
+                arguments(named("VARBINARY", JDBCType.VARBINARY), "VARBINARY", { f: Int -> resultSet.getBytes(f) }),
+                arguments(named("BIT", JDBCType.BIT), "BIT", { f: Int -> resultSet.getBoolean(f) }),
+                arguments(named("BOOLEAN", JDBCType.BOOLEAN), "BOOLEAN", { f: Int -> resultSet.getBoolean(f) }),
+                arguments(named("CLOB", JDBCType.CLOB), "CLOB", { f: Int -> resultSet.getString(f) }),
                 arguments(
                     named("LONGNVARCHAR", JDBCType.LONGNVARCHAR),
                     "LONGNVARCHAR",
-                    { f: String -> resultSet.getString(f) },
+                    { f: Int -> resultSet.getString(f) },
                 ),
                 arguments(
                     named("LONGVARCHAR", JDBCType.LONGVARCHAR),
                     "LONGVARCHAR",
-                    { f: String -> resultSet.getString(f) },
+                    { f: Int -> resultSet.getString(f) },
                 ),
-                arguments(named("NCHAR", JDBCType.NCHAR), "NCHAR", { f: String -> resultSet.getString(f) }),
-                arguments(named("NCLOB", JDBCType.NCLOB), "NCLOB", { f: String -> resultSet.getString(f) }),
-                arguments(named("NVARCHAR", JDBCType.NVARCHAR), "NVARCHAR", { f: String -> resultSet.getString(f) }),
-                arguments(named("ROWID", JDBCType.ROWID), "ROWID", { f: String -> resultSet.getString(f) }),
-                arguments(named("SQLXML", JDBCType.SQLXML), "SQLXML", { f: String -> resultSet.getString(f) }),
-                arguments(named("VARCHAR", JDBCType.VARCHAR), "VARCHAR", { f: String -> resultSet.getString(f) }),
-                arguments(named("DATE", JDBCType.DATE), "DATE", { f: String -> resultSet.getDate(f) }),
-                arguments(named("DECIMAL", JDBCType.DECIMAL), "DECIMAL", { f: String -> resultSet.getFloat(f) }),
-                arguments(named("FLOAT", JDBCType.FLOAT), "FLOAT", { f: String -> resultSet.getFloat(f) }),
-                arguments(named("NUMERIC", JDBCType.NUMERIC), "NUMERIC", { f: String -> resultSet.getFloat(f) }),
-                arguments(named("REAL", JDBCType.REAL), "REAL", { f: String -> resultSet.getFloat(f) }),
-                arguments(named("DOUBLE", JDBCType.DOUBLE), "DOUBLE", { f: String -> resultSet.getDouble(f) }),
-                arguments(named("INTEGER", JDBCType.INTEGER), "INTEGER", { f: String -> resultSet.getInt(f) }),
-                arguments(named("SMALLINT", JDBCType.SMALLINT), "SMALLINT", { f: String -> resultSet.getInt(f) }),
-                arguments(named("TINYINT", JDBCType.TINYINT), "TINYINT", { f: String -> resultSet.getInt(f) }),
+                arguments(named("NCHAR", JDBCType.NCHAR), "NCHAR", { f: Int -> resultSet.getString(f) }),
+                arguments(named("NCLOB", JDBCType.NCLOB), "NCLOB", { f: Int -> resultSet.getString(f) }),
+                arguments(named("NVARCHAR", JDBCType.NVARCHAR), "NVARCHAR", { f: Int -> resultSet.getString(f) }),
+                arguments(named("ROWID", JDBCType.ROWID), "ROWID", { f: Int -> resultSet.getString(f) }),
+                arguments(named("SQLXML", JDBCType.SQLXML), "SQLXML", { f: Int -> resultSet.getString(f) }),
+                arguments(named("VARCHAR", JDBCType.VARCHAR), "VARCHAR", { f: Int -> resultSet.getString(f) }),
+                arguments(named("DATE", JDBCType.DATE), "DATE", { f: Int -> resultSet.getDate(f) }),
+                arguments(named("DECIMAL", JDBCType.DECIMAL), "DECIMAL", { f: Int -> resultSet.getFloat(f) }),
+                arguments(named("FLOAT", JDBCType.FLOAT), "FLOAT", { f: Int -> resultSet.getFloat(f) }),
+                arguments(named("NUMERIC", JDBCType.NUMERIC), "NUMERIC", { f: Int -> resultSet.getFloat(f) }),
+                arguments(named("REAL", JDBCType.REAL), "REAL", { f: Int -> resultSet.getFloat(f) }),
+                arguments(named("DOUBLE", JDBCType.DOUBLE), "DOUBLE", { f: Int -> resultSet.getDouble(f) }),
+                arguments(named("INTEGER", JDBCType.INTEGER), "INTEGER", { f: Int -> resultSet.getInt(f) }),
+                arguments(named("SMALLINT", JDBCType.SMALLINT), "SMALLINT", { f: Int -> resultSet.getInt(f) }),
+                arguments(named("TINYINT", JDBCType.TINYINT), "TINYINT", { f: Int -> resultSet.getInt(f) }),
                 arguments(
                     named("JAVA_OBJECT", JDBCType.JAVA_OBJECT),
                     "JAVA_OBJECT",
-                    { f: String -> resultSet.getObject(f) },
+                    { f: Int -> resultSet.getObject(f) },
                 ),
-                arguments(named("TIME", JDBCType.TIME), "TIME", { f: String -> resultSet.getTime(f) }),
+                arguments(named("TIME", JDBCType.TIME), "TIME", { f: Int -> resultSet.getTime(f) }),
                 arguments(
                     named("TIME_WITH_TIMEZONE", JDBCType.TIME),
                     "TIME_WITH_TIMEZONE",
-                    { f: String -> resultSet.getTime(f) },
+                    { f: Int -> resultSet.getTime(f) },
                 ),
-                arguments(named("TIMESTAMP", JDBCType.TIMESTAMP), "TIMESTAMP", { f: String -> resultSet.getTimestamp(f) }),
+                arguments(named("TIMESTAMP", JDBCType.TIMESTAMP), "TIMESTAMP", { f: Int -> resultSet.getTimestamp(f) }),
                 arguments(
                     named("TIMESTAMP_WITH_TIMEZONE", JDBCType.TIMESTAMP_WITH_TIMEZONE),
                     "TIMESTAMP_WITH_TIMEZONE",
-                    { f: String -> resultSet.getTimestamp(f) },
+                    { f: Int -> resultSet.getTimestamp(f) },
                 ),
             )
 
@@ -179,24 +179,24 @@ class SQLTypesConverterTest {
     fun `should convert SQL types correctly`(
         jdbcType: JDBCType,
         sqlTypeName: String,
-        expectedGetter: (String) -> Any,
+        expectedGetter: (Int) -> Any,
     ) {
-        SQLTypesConverter.convertSQLType(jdbcType, sqlTypeName, resultSet, "foo")
-        verify { expectedGetter("foo") }
+        SQLTypesConverter.convertSQLType(jdbcType, sqlTypeName, resultSet, 1)
+        verify { expectedGetter(1) }
     }
 
     @ParameterizedTest
     @MethodSource("convertSQLTypeUnsupportedTests")
     fun `unsupported SQL types throws`(jdbcType: JDBCType) {
         assertThrows<KapperUnsupportedOperationException> {
-            SQLTypesConverter.convertSQLType(jdbcType, jdbcType.toString(), resultSet, "foo")
+            SQLTypesConverter.convertSQLType(jdbcType, jdbcType.toString(), resultSet, 1)
         }
     }
 
     @Test
     fun `char needs truncating`() {
-        every { resultSet.getString("char") } returns "example"
-        val result = SQLTypesConverter.convertSQLType(JDBCType.CHAR, "CHAR", resultSet, "char")
+        every { resultSet.getString(1) } returns "example"
+        val result = SQLTypesConverter.convertSQLType(JDBCType.CHAR, "CHAR", resultSet, 1)
 
         result.shouldBe('e')
     }
@@ -204,8 +204,8 @@ class SQLTypesConverterTest {
     @Test
     fun `uuid needs parsing`() {
         val id = UUID.randomUUID()
-        every { resultSet.getString("uuid") } returns id.toString()
-        val result = SQLTypesConverter.convertSQLType(JDBCType.OTHER, "UUID", resultSet, "uuid")
+        every { resultSet.getString(2) } returns id.toString()
+        val result = SQLTypesConverter.convertSQLType(JDBCType.OTHER, "UUID", resultSet, 2)
 
         result.shouldBe(id)
     }
@@ -213,8 +213,8 @@ class SQLTypesConverterTest {
     @Test
     fun `time needs converting`() {
         val time = LocalTime.now().truncatedTo(ChronoUnit.SECONDS)
-        every { resultSet.getTime("time") } returns Time.valueOf(time)
-        val result = SQLTypesConverter.convertSQLType(JDBCType.TIME, "time", resultSet, "time")
+        every { resultSet.getTime(3) } returns Time.valueOf(time)
+        val result = SQLTypesConverter.convertSQLType(JDBCType.TIME, "time", resultSet, 3)
 
         result.shouldBe(time)
     }
@@ -222,8 +222,8 @@ class SQLTypesConverterTest {
     @Test
     fun `time with zone needs converting`() {
         val time = LocalTime.now().truncatedTo(ChronoUnit.SECONDS)
-        every { resultSet.getTime("time-zone") } returns Time.valueOf(time)
-        val result = SQLTypesConverter.convertSQLType(JDBCType.TIME_WITH_TIMEZONE, "time", resultSet, "time-zone")
+        every { resultSet.getTime(4) } returns Time.valueOf(time)
+        val result = SQLTypesConverter.convertSQLType(JDBCType.TIME_WITH_TIMEZONE, "time", resultSet, 4)
 
         result.shouldBe(time)
     }
@@ -231,8 +231,8 @@ class SQLTypesConverterTest {
     @Test
     fun `timestamp needs converting`() {
         val timestamp = Instant.now()
-        every { resultSet.getTimestamp("timestamp") } returns Timestamp.from(timestamp)
-        val result = SQLTypesConverter.convertSQLType(JDBCType.TIMESTAMP, "timestamp", resultSet, "timestamp")
+        every { resultSet.getTimestamp(5) } returns Timestamp.from(timestamp)
+        val result = SQLTypesConverter.convertSQLType(JDBCType.TIMESTAMP, "timestamp", resultSet, 5)
 
         result.shouldBe(timestamp)
     }
@@ -240,8 +240,8 @@ class SQLTypesConverterTest {
     @Test
     fun `timestamp with zone needs converting`() {
         val timestamp = Instant.now()
-        every { resultSet.getTimestamp("timestamp-zone") } returns Timestamp.from(timestamp)
-        val result = SQLTypesConverter.convertSQLType(JDBCType.TIMESTAMP_WITH_TIMEZONE, "timestamp", resultSet, "timestamp-zone")
+        every { resultSet.getTimestamp(6) } returns Timestamp.from(timestamp)
+        val result = SQLTypesConverter.convertSQLType(JDBCType.TIMESTAMP_WITH_TIMEZONE, "timestamp", resultSet, 6)
 
         result.shouldBe(timestamp)
     }


### PR DESCRIPTION
Fix mapping issue when column name is not the same as column label in mySQL driver.
Use index instead of column name for retrieving.
Also convert fields to lower case when mapping.