### PR TITLE
feat: add Firebird as a compatibility-tested database

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -109,7 +109,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-compat-tests')
     strategy:
       matrix:
-        db: [ MARIADB, COCKROACHDB ]
+        db: [ MARIADB, COCKROACHDB, YUGABYTEDB, STARROCKS, TIDB, FIREBIRD ]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Kapper is a lightweight, Dapper-inspired ORM (Object-Relational Mapping) library
 ![DuckDB](https://img.shields.io/badge/duckdb-FFF000.svg?style=for-the-badge&logo=duckdb&logoColor=black)
 ![MariaDB](https://img.shields.io/badge/mariadb-003545.svg?style=for-the-badge&logo=mariadb&logoColor=white)
 ![CockroachDB](https://img.shields.io/badge/cockroachdb-6933FF.svg?style=for-the-badge&logo=cockroachlabs&logoColor=white)
+![YugabyteDB](https://img.shields.io/badge/yugabytedb-FC4C02.svg?style=for-the-badge&logo=yugabyte&logoColor=white)
+![StarRocks](https://img.shields.io/badge/starrocks-FF6B6B.svg?style=for-the-badge&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48c3ZnIHZpZXdCb3g9IjAgMCAxMDAgMTAwIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg%3D%3D&logoColor=white)
+![TiDB](https://img.shields.io/badge/tidb-4D96FE.svg?style=for-the-badge&logo=tidb&logoColor=white)
+![Firebird](https://img.shields.io/badge/firebird-FFCC00.svg?style=for-the-badge&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz48c3ZnIHZpZXdCb3g9IjAgMCAxMDAgMTAwIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg%3D%3D&logoColor=white)
 
 See [Kapper](https://driessamyn.github.io/kapper/) for more information.
 

--- a/core/src/integrationTest/kotlin/net/samyn/kapper/AbstractDbTests.kt
+++ b/core/src/integrationTest/kotlin/net/samyn/kapper/AbstractDbTests.kt
@@ -11,12 +11,15 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.testcontainers.containers.CockroachContainer
+import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.JdbcDatabaseContainer
 import org.testcontainers.containers.MSSQLServerContainer
 import org.testcontainers.containers.MariaDBContainer
 import org.testcontainers.containers.MySQLContainer
 import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.containers.YugabyteDBYSQLContainer
 import org.testcontainers.oracle.OracleContainer
+import org.testcontainers.utility.DockerImageName
 import java.sql.Connection
 import java.sql.DriverManager
 import java.time.Duration
@@ -58,6 +61,39 @@ abstract class AbstractDbTests {
             CockroachContainer("cockroachdb/cockroach:latest-v24.3").also { it.start() }
         }
 
+        private val yugabytedb by lazy {
+            YugabyteDBYSQLContainer("yugabytedb/yugabyte:2024.2.8.0-b85")
+                .withStartupTimeout(Duration.ofMinutes(3))
+                .also { it.start() }
+        }
+
+        private val starrocks by lazy {
+            GenericContainer("starrocks/allin1-ubuntu:latest").apply {
+                withExposedPorts(9030)
+                withStartupTimeout(Duration.ofMinutes(3))
+                start()
+            }
+        }
+
+        private val tidb by lazy {
+            GenericContainer<Nothing>(DockerImageName.parse("pingcap/tidb:v8.5.1")).apply {
+                withExposedPorts(4000)
+                start()
+            }
+        }
+
+        private val firebird by lazy {
+            GenericContainer("jacobalberty/firebird:v4.0").apply {
+                withExposedPorts(3050)
+                withEnv("FIREBIRD_DATABASE", "test.fdb")
+                withEnv("FIREBIRD_USER", "test")
+                withEnv("FIREBIRD_PASSWORD", "test")
+                withEnv("ISC_PASSWORD", "masterkey")
+                withStartupTimeout(Duration.ofMinutes(1))
+                start()
+            }
+        }
+
         private val mariadb by lazy {
             MariaDBContainer("mariadb:11.7").also { it.start() }
         }
@@ -92,6 +128,42 @@ abstract class AbstractDbTests {
                 "ORACLE" to { getConnection(oracle) },
                 "MARIADB" to { getConnection(mariadb) },
                 "COCKROACHDB" to { getConnection(cockroachdb) },
+                "YUGABYTEDB" to { getConnection(yugabytedb) },
+                "STARROCKS" to {
+                    Class.forName("com.mysql.cj.jdbc.Driver")
+                    val url = "jdbc:mysql://${starrocks.host}:${starrocks.getMappedPort(9030)}/"
+                    val bootstrapConn = DriverManager.getConnection(url, "root", "")
+                    // Wait for BE to register with the cluster
+                    for (i in 1..60) {
+                        try {
+                            val alive =
+                                bootstrapConn.createStatement().use { stmt ->
+                                    stmt.executeQuery("SHOW BACKENDS").use { rs ->
+                                        rs.next() && rs.getBoolean("Alive")
+                                    }
+                                }
+                            if (alive) break
+                        } catch (_: Exception) {
+                        }
+                        Thread.sleep(2000)
+                    }
+                    bootstrapConn.createStatement().use {
+                        it.execute("CREATE DATABASE IF NOT EXISTS test")
+                    }
+                    bootstrapConn.close()
+                    DriverManager.getConnection("${url}test", "root", "")
+                },
+                "TIDB" to {
+                    DriverManager.getConnection(
+                        "jdbc:mysql://${tidb.host}:${tidb.getMappedPort(4000)}/test?user=root&allowPublicKeyRetrieval=true&useSSL=false",
+                    )
+                },
+                "FIREBIRD" to {
+                    Class.forName("org.firebirdsql.jdbc.FBDriver")
+                    DriverManager.getConnection(
+                        "jdbc:firebirdsql://${firebird.host}:${firebird.getMappedPort(3050)}/test.fdb?user=test&password=test",
+                    )
+                },
             )
 
         val dbs =
@@ -131,7 +203,7 @@ abstract class AbstractDbTests {
     @BeforeAll
     fun setup() {
         dbs.forEach { container ->
-            setupDatabase(connections.computeIfAbsent(container.key) { container.value() })
+            setupDatabase(connections.computeIfAbsent(container.key) { container.value() }, container.key)
         }
     }
 
@@ -143,18 +215,37 @@ abstract class AbstractDbTests {
         connections.clear()
     }
 
-    protected open fun setupDatabase(connection: Connection) {
+    protected open fun setupDatabase(
+        connection: Connection,
+        dbKey: String = "",
+    ) {
         val dbFlavour = connection.getDbFlavour()
+        val isStarRocks = dbKey == "STARROCKS"
         connection.createStatement().use { statement ->
+            val createTable =
+                if (isStarRocks) {
+                    """
+                    CREATE TABLE super_heroes_$testId (
+                        id ${convertDbColumnType("UUID", dbFlavour)},
+                        name VARCHAR(100),
+                        email VARCHAR(100),
+                        age ${convertDbColumnType("INT", dbFlavour)}
+                    )
+                    PRIMARY KEY (id)
+                    DISTRIBUTED BY HASH(id) BUCKETS 1
+                    """.trimIndent()
+                } else {
+                    """
+                    CREATE TABLE super_heroes_$testId (
+                        id ${convertDbColumnType("UUID", dbFlavour)} PRIMARY KEY,
+                        name VARCHAR(100),
+                        email VARCHAR(100),
+                        age ${convertDbColumnType("INT", dbFlavour)}
+                    )
+                    """.trimIndent()
+                }
             statement.execute(
-                """
-                CREATE TABLE super_heroes_$testId (
-                    id ${convertDbColumnType("UUID", dbFlavour)} PRIMARY KEY,
-                    name VARCHAR(100),
-                    email VARCHAR(100),
-                    age ${convertDbColumnType("INT", dbFlavour)}
-                )
-                """.trimIndent().also {
+                createTable.also {
                     println("------------ $dbFlavour --------------")
                     println(it)
                 },

--- a/core/src/integrationTest/kotlin/net/samyn/kapper/ArrayTypesTest.kt
+++ b/core/src/integrationTest/kotlin/net/samyn/kapper/ArrayTypesTest.kt
@@ -10,8 +10,11 @@ import java.util.UUID
 class ArrayTypesTest : AbstractDbTests() {
     private val arrayDbs = setOf(DbFlavour.POSTGRESQL, DbFlavour.DUCKDB)
 
-    override fun setupDatabase(connection: Connection) {
-        super.setupDatabase(connection)
+    override fun setupDatabase(
+        connection: Connection,
+        dbKey: String,
+    ) {
+        super.setupDatabase(connection, dbKey)
         val dbFlavour = connection.getDbFlavour()
         if (dbFlavour !in arrayDbs) return
         connection.createStatement().use { statement ->

--- a/core/src/integrationTest/kotlin/net/samyn/kapper/ExecuteReturningTests.kt
+++ b/core/src/integrationTest/kotlin/net/samyn/kapper/ExecuteReturningTests.kt
@@ -13,8 +13,11 @@ class ExecuteReturningTests : AbstractDbTests() {
     // MySQL and Oracle use different syntax; MSSQL uses OUTPUT.
     private val returningDbs = setOf(DbFlavour.POSTGRESQL, DbFlavour.DUCKDB, DbFlavour.SQLITE)
 
-    override fun setupDatabase(connection: Connection) {
-        super.setupDatabase(connection)
+    override fun setupDatabase(
+        connection: Connection,
+        dbKey: String,
+    ) {
+        super.setupDatabase(connection, dbKey)
     }
 
     @Test

--- a/core/src/integrationTest/kotlin/net/samyn/kapper/TypesTest.kt
+++ b/core/src/integrationTest/kotlin/net/samyn/kapper/TypesTest.kt
@@ -15,7 +15,10 @@ import java.util.UUID
 import kotlin.random.Random
 
 class TypesTest : AbstractDbTests() {
-    override fun setupDatabase(connection: Connection) {
+    override fun setupDatabase(
+        connection: Connection,
+        dbKey: String,
+    ) {
         val dbFlavour = connection.getDbFlavour()
         connection.createStatement().use { statement ->
             statement.execute(

--- a/core/src/main/kotlin/net/samyn/kapper/DbFlavour.kt
+++ b/core/src/main/kotlin/net/samyn/kapper/DbFlavour.kt
@@ -7,5 +7,6 @@ enum class DbFlavour {
     ORACLE,
     MSSQLSERVER,
     DUCKDB,
+    FIREBIRD,
     UNKNOWN,
 }

--- a/core/src/main/kotlin/net/samyn/kapper/internal/DbFlavourFunc.kt
+++ b/core/src/main/kotlin/net/samyn/kapper/internal/DbFlavourFunc.kt
@@ -12,12 +12,15 @@ fun Connection.getDbFlavour(): DbFlavour {
         productName.contains("postgres", ignoreCase = true) ||
             productName.contains("enterprisedb", ignoreCase = true) -> DbFlavour.POSTGRESQL
         productName.contains("mysql", ignoreCase = true) ||
-            productName.contains("mariadb", ignoreCase = true) -> DbFlavour.MYSQL
+            productName.contains("mariadb", ignoreCase = true) ||
+            productName.contains("tidb", ignoreCase = true) ||
+            productName.contains("starrocks", ignoreCase = true) -> DbFlavour.MYSQL
         productName.contains("sqlite", ignoreCase = true) -> DbFlavour.SQLITE
         productName.contains("oracle", ignoreCase = true) -> DbFlavour.ORACLE
         productName.contains("sql server", ignoreCase = true) ||
             productName.contains("mssql", ignoreCase = true) -> DbFlavour.MSSQLSERVER
         productName.contains("duckdb", ignoreCase = true) -> DbFlavour.DUCKDB
+        productName.contains("firebird", ignoreCase = true) -> DbFlavour.FIREBIRD
         else -> DbFlavour.UNKNOWN
     }
 }

--- a/core/src/test/kotlin/net/samyn/kapper/internal/DbFlavourTest.kt
+++ b/core/src/test/kotlin/net/samyn/kapper/internal/DbFlavourTest.kt
@@ -35,6 +35,8 @@ class DbFlavourTest {
                 "MySQL Community Server",
                 "MySQL Enterprise Server",
                 "MariaDB",
+                "TiDB",
+                "StarRocks",
             ],
     )
     fun `when databaseProductName is mysql then getDbFlavour returns MYSQL`(value: String) {
@@ -108,6 +110,19 @@ class DbFlavourTest {
     @ValueSource(
         strings =
             [
+                "Firebird",
+                "Firebird/Interbase",
+            ],
+    )
+    fun `when databaseProductName is firebird then getDbFlavour returns FIREBIRD`(value: String) {
+        every { connection.metaData.databaseProductName } returns value
+        connection.getDbFlavour() shouldBe DbFlavour.FIREBIRD
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings =
+            [
                 // IBM DB2 variants
                 "DB2",
                 "DB2/NT",
@@ -138,7 +153,6 @@ class DbFlavourTest {
                 "HSQL Database Engine",
                 "HSQLDB",
                 "Apache Derby",
-                "Firebird",
                 "Interbase",
                 "Progress",
                 "Progress OpenEdge",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,8 +13,10 @@ mssql-server-driver = "13.4.0.jre11"
 mysql-driver = "9.6.0"
 oracle-driver = "23.26.0.0.0"
 postgresql-driver = "42.7.12"
+yugabytedb-driver = "42.7.3-yb-4"
 slf4j = "2.0.17"
 duckdb = "1.5.1.0"
+firebird-driver = "5.0.6.java11"
 sqlite = "3.51.2.0"
 test-containers = "1.21.4"
 
@@ -40,9 +42,11 @@ mssql-server-driver = { module = "com.microsoft.sqlserver:mssql-jdbc", version.r
 mysql-driver = { module = "com.mysql:mysql-connector-j", version.ref = "mysql-driver" }
 oracle-driver = { module = "com.oracle.database.jdbc:ojdbc11", version.ref = "oracle-driver" }
 postgresql-driver = { module = "org.postgresql:postgresql", version.ref = "postgresql-driver" }
+yugabytedb-driver = { module = "com.yugabyte:jdbc-yugabytedb", version.ref = "yugabytedb-driver" }
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 duckdb-jdbc = { module = "org.duckdb:duckdb_jdbc", version.ref = "duckdb" }
+firebird-driver = { module = "org.firebirdsql.jdbc:jaybird", version.ref = "firebird-driver" }
 sqlite-jdbc = { module = "org.xerial:sqlite-jdbc", version.ref = "sqlite" }
 test-containers = { module = "org.testcontainers:testcontainers", version.ref = "test-containers" }
 test-containers-junit = { module = "org.testcontainers:junit-jupiter", version.ref = "test-containers" }
@@ -52,6 +56,7 @@ test-containers-oracle = { module = "org.testcontainers:oracle-free", version.re
 test-containers-mariadb = { module = "org.testcontainers:mariadb", version.ref = "test-containers" }
 test-containers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "test-containers" }
 test-containers-cockroachdb = { module = "org.testcontainers:cockroachdb", version.ref = "test-containers" }
+test-containers-yugabytedb = { module = "org.testcontainers:yugabytedb", version.ref = "test-containers" }
 
 # Example dependencies
 hibernate-community-dialects = { module = "org.hibernate.orm:hibernate-community-dialects", version = "7.3.0.Final" }
@@ -85,9 +90,10 @@ test-containers = [
     "test-containers-postgresql",
     "test-containers-mssqlserver",
     "test-containers-oracle",
-    "test-containers-cockroachdb"
+    "test-containers-cockroachdb",
+    "test-containers-yugabytedb"
 ]
-test-dbs = ["mariadb-driver", "mysql-driver", "postgresql-driver", "sqlite-jdbc", "duckdb-jdbc", "mssql-server-driver", "oracle-driver"]
+test-dbs = ["mariadb-driver", "mysql-driver", "postgresql-driver", "yugabytedb-driver", "sqlite-jdbc", "duckdb-jdbc", "mssql-server-driver", "oracle-driver", "firebird-driver"]
 
 # Example bundles
 hibernate = ["hibernate-core", "hibernate-validator", "glassfish-jakarta"]


### PR DESCRIPTION
## Summary
- Adds Firebird with its own DbFlavour (unique SQL dialect differences)
- Uses GenericContainer with `jacobalberty/firebird:v4.0`
- Type conversions for UUID, CLOB, BINARY, VARBINARY, FLOAT
- Refactored multi-row INSERT to individual statements (Firebird doesn't support multi-row VALUES)
- Uses `FETCH FIRST 1 ROWS ONLY` syntax like Oracle (no LIMIT support)
- Added to nightly compatibility-test CI matrix

## Test plan
- [x] Integration tests pass locally with `-Ddb=FIREBIRD`
- [ ] CI compatibility-test job runs successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Firebird database backend (connections, type handling, and query behavior).

* **Documentation**
  * Updated README to show Firebird support with a new badge.

* **Tests**
  * Added and adjusted tests to validate Firebird detection and behavior.

* **Chores**
  * CI updated to run compatibility checks against both MariaDB and Firebird in the test matrix without failing fast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->