### PR TITLE
feat: add CockroachDB as a compatibility-tested database

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -126,7 +126,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-compat-tests')
     strategy:
       matrix:
-        db: [ MARIADB ]
+        db: [ MARIADB, COCKROACHDB ]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Kapper is a lightweight, Dapper-inspired ORM (Object-Relational Mapping) library
 ![MSSQL](https://img.shields.io/badge/mssql-%23CC2927.svg?style=for-the-badge&logo=microsoftsqlserver&logoColor=white)
 ![DuckDB](https://img.shields.io/badge/duckdb-FFF000.svg?style=for-the-badge&logo=duckdb&logoColor=black)
 ![MariaDB](https://img.shields.io/badge/mariadb-003545.svg?style=for-the-badge&logo=mariadb&logoColor=white)
+![CockroachDB](https://img.shields.io/badge/cockroachdb-6933FF.svg?style=for-the-badge&logo=cockroachlabs&logoColor=white)
 
 See [Kapper](https://driessamyn.github.io/kapper/) for more information.
 

--- a/core/src/integrationTest/kotlin/net/samyn/kapper/AbstractDbTests.kt
+++ b/core/src/integrationTest/kotlin/net/samyn/kapper/AbstractDbTests.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.params.ParameterizedClass
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.testcontainers.containers.CockroachContainer
 import org.testcontainers.containers.JdbcDatabaseContainer
 import org.testcontainers.containers.MSSQLServerContainer
 import org.testcontainers.containers.MariaDBContainer
@@ -53,6 +54,10 @@ abstract class AbstractDbTests {
                 .also { it.start() }
         }
 
+        private val cockroachdb by lazy {
+            CockroachContainer("cockroachdb/cockroach:latest-v24.3").also { it.start() }
+        }
+
         private val mariadb by lazy {
             MariaDBContainer("mariadb:11.7").also { it.start() }
         }
@@ -86,6 +91,7 @@ abstract class AbstractDbTests {
                 "MSSQLSERVER" to { getConnection(msSqlServer) },
                 "ORACLE" to { getConnection(oracle) },
                 "MARIADB" to { getConnection(mariadb) },
+                "COCKROACHDB" to { getConnection(cockroachdb) },
             )
 
         val dbs =

--- a/core/src/main/kotlin/net/samyn/kapper/internal/Converters.kt
+++ b/core/src/main/kotlin/net/samyn/kapper/internal/Converters.kt
@@ -177,6 +177,12 @@ internal fun convertChar(value: Any): Char =
 internal fun convertInt(value: Any): Int =
     when (value) {
         is Integer -> value.toInt()
+        is java.lang.Long -> {
+            if (value < Int.MIN_VALUE.toLong() || value > Int.MAX_VALUE.toLong()) {
+                throw KapperParseException("Cannot parse $value to Int (out of range)")
+            }
+            value.toInt()
+        }
         is java.lang.Float -> value.toInt()
         is Float -> value.toInt()
         is BigDecimal -> value.toInt()

--- a/core/src/main/kotlin/net/samyn/kapper/internal/DbFlavourFunc.kt
+++ b/core/src/main/kotlin/net/samyn/kapper/internal/DbFlavourFunc.kt
@@ -8,6 +8,7 @@ import java.sql.Connection
 fun Connection.getDbFlavour(): DbFlavour {
     val productName = this.metaData.databaseProductName
     return when {
+        productName.contains("cockroach", ignoreCase = true) -> DbFlavour.POSTGRESQL
         productName.contains("postgres", ignoreCase = true) ||
             productName.contains("enterprisedb", ignoreCase = true) -> DbFlavour.POSTGRESQL
         productName.contains("mysql", ignoreCase = true) ||

--- a/core/src/test/kotlin/net/samyn/kapper/internal/DbFlavourTest.kt
+++ b/core/src/test/kotlin/net/samyn/kapper/internal/DbFlavourTest.kt
@@ -18,6 +18,7 @@ class DbFlavourTest {
                 "PostgreSQL",
                 "Postgres",
                 "EnterpriseDB",
+                "CockroachDB",
             ],
     )
     fun `when databaseProductName is postgresql then getDbFlavour returns POSTGRESQL`(value: String) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ test-containers-mysql = { module = "org.testcontainers:mysql", version.ref = "te
 test-containers-oracle = { module = "org.testcontainers:oracle-free", version.ref = "test-containers" }
 test-containers-mariadb = { module = "org.testcontainers:mariadb", version.ref = "test-containers" }
 test-containers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "test-containers" }
+test-containers-cockroachdb = { module = "org.testcontainers:cockroachdb", version.ref = "test-containers" }
 
 # Example dependencies
 hibernate-community-dialects = { module = "org.hibernate.orm:hibernate-community-dialects", version = "7.3.0.Final" }
@@ -83,7 +84,8 @@ test-containers = [
     "test-containers-mysql",
     "test-containers-postgresql",
     "test-containers-mssqlserver",
-    "test-containers-oracle"
+    "test-containers-oracle",
+    "test-containers-cockroachdb"
 ]
 test-dbs = ["mariadb-driver", "mysql-driver", "postgresql-driver", "sqlite-jdbc", "duckdb-jdbc", "mssql-server-driver", "oracle-driver"]
 


### PR DESCRIPTION
## Summary
- Adds CockroachDB compatibility testing (PostgreSQL wire-compatible, detected as DbFlavour.POSTGRESQL)
- Uses CockroachContainer with `cockroachdb/cockroach:latest-v24.3`
- Fixed `convertInt` to handle Long→Int conversion (CockroachDB returns INT8 for integer columns)
- Added to nightly compatibility-test CI matrix

## Test plan
- [x] Integration tests pass locally with `-Ddb=COCKROACHDB`
- [ ] CI compatibility-test job runs successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CockroachDB as a supported database and included it in compatibility test runs.

* **Bug Fixes**
  * Integer conversion now properly handles long values with range checking and clear errors for out-of-range inputs.

* **Tests**
  * Extended database-detection tests and integration test matrix to cover CockroachDB.

* **Chores**
  * Updated documentation badge and test tooling configuration to reflect CockroachDB support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->